### PR TITLE
Add tensorboard logging during model training

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "modules/llama.cpp"]
 	path = modules/llama.cpp
-	url = https://github.com/gkielian/llama.cpp.git
+	url = https://github.com/ggerganov/llama.cpp

--- a/config/train_modular_addition.py
+++ b/config/train_modular_addition.py
@@ -1,32 +1,43 @@
 # Configuration for a modular arithmetic training
 
-out_dir = 'out-modular-arithmetic'
-eval_interval = 2 # frequency increased for train vs val monitoring
+out_dir = "out-modular-arithmetic"
+eval_interval = 5  # frequency increased for train vs val monitoring
 eval_iters = 200
-log_interval = 2 # decreased for higher resolution
+log_interval = 5 # decreased for higher resolution
 
-always_save_checkpoint = False
+always_save_checkpoint = False # this just says it saves whenever val improves
+only_save_checkpoint_at_end = True # this only saves at the end of training, speeding things up
 
-# wandb_log = True
-# wandb_project = 'out-modular-addition'
-# wandb_run_name = 'modular-addition'
+# logging
+log_project = "out-modular-addition"
+log_run_name = "logs-modular-addition"
 
-dataset = 'modular_addition'
+# tensorboard
+tensorboard_log = True
+tensorboard_project = log_project
+tensorboard_run_name = log_run_name
+
+# wandb
+wandb_log = False
+wandb_project = log_project
+wandb_run_name = log_run_name
+
+dataset = "modular_addition"
 gradient_accumulation_steps = 1
 batch_size = 64
 
 # Change to be `modulo + 1` if no-separator, or `modulo + 3` if there are separators
-block_size = 24
+block_size = 7
 
 # Model parameters
 n_layer = 4
 n_head = 4
-n_embd = 32
-dropout = 0.2
+n_embd = 64
+dropout = 0.4
 
 # Training parameters
 learning_rate = 1e-3
-max_iters = 5000
+max_iters = 50000
 lr_decay_iters = 5000
 min_lr = 1e-4
 beta2 = 0.99
@@ -35,4 +46,3 @@ warmup_iters = 100
 # Uncomment the lines below if running on a MacBook without GPU
 # device = 'cpu'
 # compile = False
-

--- a/data/modular_addition/create_examples.sh
+++ b/data/modular_addition/create_examples.sh
@@ -10,7 +10,7 @@ fi
 
 for i in "${bases[@]}"; do
   echo "$i"
-  python print_bases_mod_x.py --modulo 128 --no_separator --base "$i" --seed 16 > "./${data_dir}/base_${i}.txt"
+  python print_bases_mod_x.py --modulo 16 --no_separator --base "$i" --seed 16 > "./${data_dir}/base_${i}.txt"
   # python print_bases_mod_x.py --modulo 128  --base "$i" --seed 16 > "./${data_dir}/base_${i}.txt"
 done
 

--- a/start_tensorboard.sh
+++ b/start_tensorboard.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Note: may need to run this script as `source start_tensorboard.sh` to utilize environment
+
+tensorboard --logdir=./logs # creates and starts logging logs into the logs folder


### PR DESCRIPTION

`train.py`:
- Added tensorboard logging with train and val loss on same graph.

`start_tensorboard.sh`:
- Added a helper script for tensorboard logger.

`config/train_modular_addition.py`:
- Modified context to match toy example in the generated examples.
- Modified the settings to those close to the grokking paper.
- Added feature for saving checkpoint only at the end (hoping to prevent
excessive checkpoint saves when doing frequent validation loss
logging)
