### PR TITLE
Parameterize train.py

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "modules/llama.cpp"]
 	path = modules/llama.cpp
-	url = https://github.com/gkielian/llama.cpp.git
+	url = https://github.com/ggerganov/llama.cpp

--- a/config/train_modular_addition.py
+++ b/config/train_modular_addition.py
@@ -1,32 +1,43 @@
 # Configuration for a modular arithmetic training
 
-out_dir = 'out-modular-arithmetic'
-eval_interval = 2 # frequency increased for train vs val monitoring
+out_dir = "out-modular-arithmetic"
+eval_interval = 5  # frequency increased for train vs val monitoring
 eval_iters = 200
-log_interval = 2 # decreased for higher resolution
+log_interval = 5 # decreased for higher resolution
 
-always_save_checkpoint = False
+always_save_checkpoint = False # this just says it saves whenever val improves
+only_save_checkpoint_at_end = True # this only saves at the end of training, speeding things up
 
-# wandb_log = True
-# wandb_project = 'out-modular-addition'
-# wandb_run_name = 'modular-addition'
+# logging
+log_project = "out-modular-addition"
+log_run_name = "logs-modular-addition"
 
-dataset = 'modular_addition'
+# tensorboard
+tensorboard_log = True
+tensorboard_project = log_project
+tensorboard_run_name = log_run_name
+
+# wandb
+wandb_log = False
+wandb_project = log_project
+wandb_run_name = log_run_name
+
+dataset = "modular_addition"
 gradient_accumulation_steps = 1
 batch_size = 64
 
 # Change to be `modulo + 1` if no-separator, or `modulo + 3` if there are separators
-block_size = 24
+block_size = 7
 
 # Model parameters
 n_layer = 4
 n_head = 4
-n_embd = 32
-dropout = 0.2
+n_embd = 64
+dropout = 0.4
 
 # Training parameters
 learning_rate = 1e-3
-max_iters = 5000
+max_iters = 50000
 lr_decay_iters = 5000
 min_lr = 1e-4
 beta2 = 0.99
@@ -35,4 +46,3 @@ warmup_iters = 100
 # Uncomment the lines below if running on a MacBook without GPU
 # device = 'cpu'
 # compile = False
-

--- a/data/modular_addition/create_examples.sh
+++ b/data/modular_addition/create_examples.sh
@@ -10,7 +10,7 @@ fi
 
 for i in "${bases[@]}"; do
   echo "$i"
-  python print_bases_mod_x.py --modulo 128 --no_separator --base "$i" --seed 16 > "./${data_dir}/base_${i}.txt"
+  python print_bases_mod_x.py --modulo 16 --no_separator --base "$i" --seed 16 > "./${data_dir}/base_${i}.txt"
   # python print_bases_mod_x.py --modulo 128  --base "$i" --seed 16 > "./${data_dir}/base_${i}.txt"
 done
 

--- a/start_tensorboard.sh
+++ b/start_tensorboard.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Note: may need to run this script as `source start_tensorboard.sh` to utilize environment
+
+tensorboard --logdir=./logs # creates and starts logging logs into the logs folder

--- a/train.py
+++ b/train.py
@@ -1,370 +1,362 @@
-"""
-This training script can be run both on a single gpu in debug mode,
-and also in a larger training run with distributed data parallel (ddp).
-
-To run on a single GPU, example:
-$ python train.py --batch_size=32 --compile=False
-
-To run with DDP on 4 gpus on 1 node, example:
-$ torchrun --standalone --nproc_per_node=4 train.py
-
-To run with DDP on 4 gpus across 2 nodes, example:
-- Run on the first (master) node with example IP 123.456.123.456:
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py
-- Run on the worker node:
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py
-(If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
-"""
-
+import argparse
 import os
 import time
 from datetime import datetime
 import math
 import pickle
-from contextlib import nullcontext
 
 import numpy as np
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed import init_process_group, destroy_process_group
-
 from torch.utils.tensorboard import SummaryWriter
-
 
 from model import GPTConfig, GPT
 
 
-def log_tensorboard_metrics(writer, losses, lr, running_mfu, iter_num):
-    writer.add_scalars(
-        "loss", { "train": losses['train'], "val": losses['val'] }, iter_num
-        )
-    writer.add_scalar("mfu_pct", running_mfu * 100, iter_num)
-    writer.add_scalar("lr", lr, iter_num)
+def parse_args():
+    parser = argparse.ArgumentParser()
 
-# -----------------------------------------------------------------------------
-# default config values designed to train a gpt2 (124M) on OpenWebText
-# I/O
-out_dir = 'out'
-eval_interval = 2000
-log_interval = 1
-eval_iters = 200
-eval_only = False # if True, script exits right after the first eval
-# checkpoints
-only_save_checkpoint_at_end=False
-always_save_checkpoint = True # if True, always save a checkpoint after each eval
-init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'
-# data
-dataset = 'openwebtext'
-gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes
-batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
-block_size = 1024
-# model
-n_layer = 12
-n_head = 12
-n_embd = 768
-dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+
-bias = False # do we use bias inside LayerNorm and Linear layers?
-# adamw optimizer
-learning_rate = 6e-4 # max learning rate
-max_iters = 600000 # total number of training iterations
-weight_decay = 1e-1
-beta1 = 0.9
-beta2 = 0.95
-grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0
-# learning rate decay settings
-decay_lr = True # whether to decay the learning rate
-warmup_iters = 2000 # how many steps to warm up for
-lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla
-min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla
-# DDP settings
-backend = 'nccl' # 'nccl', 'gloo', etc.
-# system
-device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
-dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
-compile = True # use PyTorch 2.0 to compile the model to be faster
-# logging
-log_project = "out-test"
-log_run_name = "logs-test"
-# tensorboard
-tensorboard_log = True
-tensorboard_project = log_project
-tensorboard_run_name = log_run_name
-writer = None
+    # I/O args
+    parser.add_argument('--out_dir', default='out', type=str)
+    parser.add_argument('--eval_interval', default=250, type=int)
+    parser.add_argument('--log_interval', default=10, type=int)
+    parser.add_argument('--eval_iters', default=200, type=int)
+    parser.add_argument('--eval_only', action='store_true')
 
-# Obtain overriding values from the config file
-# -----------------------------------------------------------------------------
-config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
-exec(open('configurator.py').read()) # overrides from command line or config file
-config = {k: globals()[k] for k in config_keys} # will be useful for logging
-# -----------------------------------------------------------------------------
+    # Checkpoint args
+    parser.add_argument('--only_save_checkpoint_at_end', action='store_true')
+    parser.add_argument('--always_save_checkpoint', action='store_true',
+                        default=False)
+    parser.add_argument('--init_from', default='scratch', choices=['scratch', 'resume', 'gpt2*'], type=str)
 
-# Setup tensorboard
-log_dir = 'logs/' + tensorboard_run_name
-timestamp = time.strftime("%Y%m%d-%H%M%S")
-log_subpath = os.path.join(log_dir, timestamp)
-if tensorboard_log:
-  writer = SummaryWriter(log_subpath)
+    # Data args
+    parser.add_argument('--dataset', default='shakespeare_char', type=str)
+    parser.add_argument('--gradient_accumulation_steps', default=1, type=int)
+    parser.add_argument('--batch_size', default=64, type=int)
+    parser.add_argument('--block_size', default=256, type=int)
 
-# various inits, derived attributes, I/O setup
-ddp = int(os.environ.get('RANK', -1)) != -1 # is this a ddp run?
-if ddp:
-    init_process_group(backend=backend)
-    ddp_rank = int(os.environ['RANK'])
-    ddp_local_rank = int(os.environ['LOCAL_RANK'])
-    ddp_world_size = int(os.environ['WORLD_SIZE'])
-    device = f'cuda:{ddp_local_rank}'
-    torch.cuda.set_device(device)
-    master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.
-    seed_offset = ddp_rank # each process gets a different seed
-    # world_size number of processes will be training simultaneously, so we can scale
-    # down the desired gradient accumulation iterations per process proportionally
-    assert gradient_accumulation_steps % ddp_world_size == 0
-    gradient_accumulation_steps //= ddp_world_size
-else:
-    # if not ddp, we are running on a single gpu, and one process
-    master_process = True
-    seed_offset = 0
-    ddp_world_size = 1
-tokens_per_iter = gradient_accumulation_steps * ddp_world_size * batch_size * block_size
-print(f"tokens per iteration will be: {tokens_per_iter:,}")
+    # Model args
+    parser.add_argument('--n_layer', default=6, type=int)
+    parser.add_argument('--n_head', default=6, type=int)
+    parser.add_argument('--n_embd', default=384, type=int)
+    parser.add_argument('--dropout', default=0.2, type=float)
+    parser.add_argument('--bias', action='store_true', default=False)
 
-if master_process:
-    os.makedirs(out_dir, exist_ok=True)
-torch.manual_seed(1337 + seed_offset)
-torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
-torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
-# note: float16 data type will automatically use a GradScaler
-ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
-ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+    # Model variations
+    parser.add_argument('--use_rmsnorm', action='store_true', default=True)
 
-# poor man's data loader
-data_dir = os.path.join('data', dataset)
-train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
-val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
-def get_batch(split):
-    data = train_data if split == 'train' else val_data
-    ix = torch.randint(len(data) - block_size, (batch_size,))
-    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
-    y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
-    if device_type == 'cuda':
-        # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
-        x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
-    else:
-        x, y = x.to(device), y.to(device)
-    return x, y
+    # Optimizer args
+    parser.add_argument('--learning_rate', default=1e-3, type=float)
+    parser.add_argument('--max_iters', default=5000, type=int)
+    parser.add_argument('--weight_decay', default=1e-1, type=float)
+    parser.add_argument('--beta1', default=0.9, type=float)
+    parser.add_argument('--beta2', default=0.99, type=float)
+    parser.add_argument('--grad_clip', default=1.0, type=float)
 
-# init these up here, can override if init_from='resume' (i.e. from a checkpoint)
-iter_num = 0
-best_val_loss = 1e9
+    # LR schedule args
+    parser.add_argument('--decay_lr', action='store_true')
+    parser.add_argument('--warmup_iters', default=100, type=int)
+    parser.add_argument('--lr_decay_iters', default=5000, type=int)
+    parser.add_argument('--min_lr', default=1e-4, type=float)
 
-# attempt to derive vocab_size from the dataset
-meta_path = os.path.join(data_dir, 'meta.pkl')
-meta_vocab_size = None
-if os.path.exists(meta_path):
-    with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
-    meta_vocab_size = meta['vocab_size']
-    print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
+    # DDP args
+    parser.add_argument('--backend', default='nccl', type=str)
 
-# model init
-model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,
-                  bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line
-if init_from == 'scratch':
-    # init a new model from scratch
-    print("Initializing a new model from scratch")
-    # determine the vocab size we'll use for from-scratch training
-    if meta_vocab_size is None:
-        print("defaulting to vocab_size of GPT-2 to 50304 (50257 rounded up for efficiency)")
-    model_args['vocab_size'] = meta_vocab_size if meta_vocab_size is not None else 50304
-    gptconf = GPTConfig(**model_args)
-    model = GPT(gptconf)
-elif init_from == 'resume':
-    print(f"Resuming training from {out_dir}")
-    # resume training from a checkpoint.
-    ckpt_path = os.path.join(out_dir, 'ckpt.pt')
-    checkpoint = torch.load(ckpt_path, map_location=device)
-    checkpoint_model_args = checkpoint['model_args']
-    # force these config attributes to be equal otherwise we can't even resume training
-    # the rest of the attributes (e.g. dropout) can stay as desired from command line
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
-        model_args[k] = checkpoint_model_args[k]
-    # create the model
-    gptconf = GPTConfig(**model_args)
-    model = GPT(gptconf)
-    state_dict = checkpoint['model']
-    # fix the keys of the state dictionary :(
-    # honestly no idea how checkpoints sometimes get this prefix, have to debug more
-    unwanted_prefix = '_orig_mod.'
-    for k,v in list(state_dict.items()):
-        if k.startswith(unwanted_prefix):
-            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
-    model.load_state_dict(state_dict)
-    iter_num = checkpoint['iter_num']
-    best_val_loss = checkpoint['best_val_loss']
-elif init_from.startswith('gpt2'):
-    print(f"Initializing from OpenAI GPT-2 weights: {init_from}")
-    # initialize from OpenAI GPT-2 weights
-    override_args = dict(dropout=dropout)
-    model = GPT.from_pretrained(init_from, override_args)
-    # read off the created config params, so we can store them into checkpoint correctly
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
-        model_args[k] = getattr(model.config, k)
-# crop down the model block size if desired, using model surgery
-if block_size < model.config.block_size:
-    model.crop_block_size(block_size)
-    model_args['block_size'] = block_size # so that the checkpoint will have the right value
-model.to(device)
+    # System args
+    parser.add_argument('--device', default='cuda', type=str)
+    parser.add_argument('--dtype', default='float16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16', type=str)
+    parser.add_argument('--compile', action='store_true', default=True)
 
-# initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+    # Logging args
+    parser.add_argument('--log_project', default='out-test', type=str)
+    parser.add_argument('--log_run_name', default='logs-test', type=str)
 
-# optimizer
-optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)
-if init_from == 'resume':
-    optimizer.load_state_dict(checkpoint['optimizer'])
-checkpoint = None # free up memory
+    # Tensorboard args
+    parser.add_argument('--tensorboard_log', action='store_true', default=True)
+    parser.add_argument('--tensorboard_log_dir', type=str, default='logs')
+    parser.add_argument('--tensorboard_project', type=str, default='out-test')
+    parser.add_argument('--tensorboard_run_name', type=str, default='logs-test')
 
-# compile the model
-if compile:
-    print("compiling the model... (takes a ~minute)")
-    unoptimized_model = model
-    model = torch.compile(model) # requires PyTorch 2.0
+    # Tensorboard args
+    parser.add_argument('--wandb_log', action='store_true', default=False)
+    parser.add_argument('--wandb_project', type=str, default='out-test')
+    parser.add_argument('--wandb_run_name', type=str, default='logs-test')
 
-# wrap model into DDP container
-if ddp:
-    model = DDP(model, device_ids=[ddp_local_rank])
+    args = parser.parse_args()
+    return args
 
-# helps estimate an arbitrarily accurate loss over either split using many batches
-@torch.no_grad()
-def estimate_loss():
-    out = {}
-    model.eval()
-    for split in ['train', 'val']:
-        losses = torch.zeros(eval_iters)
-        for k in range(eval_iters):
-            X, Y = get_batch(split)
-            with ctx:
-                logits, loss = model(X, Y)
-            losses[k] = loss.item()
-        out[split] = losses.mean()
-    model.train()
-    return out
 
-# learning rate decay scheduler (cosine with warmup)
-def get_lr(it):
-    # 1) linear warmup for warmup_iters steps
-    if it < warmup_iters:
-        return learning_rate * it / warmup_iters
-    # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
-        return min_lr
-    # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
-    assert 0 <= decay_ratio <= 1
-    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1
-    return min_lr + coeff * (learning_rate - min_lr)
+class Trainer:
+    def __init__(self, args):
+        self.args = args
+        self.setup()
 
-# logging
-if wandb_log and master_process:
-    import wandb
-    wandb.init(project=wandb_project, name=wandb_run_name, config=config)
+    def setup(self):
+        # Setup DDP
+        self.ddp = int(os.environ.get('RANK', -1)) != -1
+        if self.ddp:
+            init_process_group(backend=self.args.backend)
+            print(args)
+            self.ddp_rank = int(os.environ['RANK'])
+            self.ddp_local_rank = int(os.environ['LOCAL_RANK'])
+            self.ddp_world_size = int(os.environ['WORLD_SIZE'])
+            self.device = f'cuda:{self.ddp_local_rank}'
+            print("this is my device", self.device)
+            torch.cuda.set_device(self.device)
+            self.master_process = self.ddp_rank == 0
+            self.seed_offset = self.ddp_rank
+            self.gradient_accumulation_steps //= self.ddp_world_size
+        else:
+            self.device = self.args.device
+            self.master_process = True
+            self.seed_offset = 0
+            self.ddp_world_size = 1
 
-# training loop
-X, Y = get_batch('train') # fetch the very first batch
-t0 = time.time()
-local_iter_num = 0 # number of iterations in the lifetime of this process
-raw_model = model.module if ddp else model # unwrap DDP container if needed
-running_mfu = -1.0
-checkpoint = {}
-while True:
+        self.tokens_per_iter = self.args.gradient_accumulation_steps * self.ddp_world_size * self.args.batch_size * self.args.block_size
 
-    # determine and set the learning rate for this iteration
-    lr = get_lr(iter_num) if decay_lr else learning_rate
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
+        if self.master_process:
+            os.makedirs(self.args.out_dir, exist_ok=True)
 
-    # evaluate the loss on train/val sets and write checkpoints
-    if iter_num % eval_interval == 0 and master_process:
-        losses = estimate_loss()
-        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
-        if tensorboard_log:
-          log_tensorboard_metrics(writer, losses, lr, running_mfu, iter_num)
-        if wandb_log:
+        torch.manual_seed(1337 + self.seed_offset)
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
+        self.device_type = 'cuda' if 'cuda' in self.args.device else 'cpu'
+        self.ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[self.args.dtype]
+        self.ctx = nullcontext() if self.device_type == 'cpu' else torch.amp.autocast(device_type=self.device_type, dtype=self.ptdtype)
+
+        # Data loader
+        self.train_data = np.memmap(os.path.join('data', self.args.dataset, 'train.bin'), dtype=np.uint16, mode='r')
+        self.val_data = np.memmap(os.path.join('data', self.args.dataset, 'val.bin'), dtype=np.uint16, mode='r')
+        meta_path = os.path.join('data', self.args.dataset, 'meta.pkl')
+        self.meta_vocab_size = None
+        if os.path.exists(meta_path):
+            with open(meta_path, 'rb') as f:
+                meta = pickle.load(f)
+            self.meta_vocab_size = meta['vocab_size']
+
+        # Model
+        self.model_args = dict(n_layer=self.args.n_layer, n_head=self.args.n_head, n_embd=self.args.n_embd,
+                          block_size=self.args.block_size, bias=self.args.bias, vocab_size=None,
+                          dropout=self.args.dropout, use_rmsnorm=self.args.use_rmsnorm)
+
+        if self.args.init_from == 'scratch':
+            self.model_args['vocab_size'] = self.meta_vocab_size if self.meta_vocab_size is not None else 50304
+            gptconf = GPTConfig(**self.model_args)
+            self.model = GPT(gptconf)
+            self.iter_num = 0 # for starting from scratch
+            self.best_val_loss = 1e9 # really big number
+        elif self.args.init_from == 'resume':
+            ckpt_path = os.path.join(self.args.out_dir, 'ckpt.pt')
+            checkpoint = torch.load(ckpt_path, map_location=self.device)
+            checkpoint_model_args = checkpoint['model_args']
+            for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
+                self.model_args[k] = checkpoint_model_args[k]
+            gptconf = GPTConfig(**self.model_args)
+            self.model = GPT(gptconf)
+            state_dict = checkpoint['model']
+            for k,v in list(state_dict.items()):
+                if k.startswith('_orig_mod.'):
+                    state_dict[k[len('_orig_mod.'):]] = state_dict.pop(k)
+            self.model.load_state_dict(state_dict)
+            self.iter_num = checkpoint['iter_num']
+            self.best_val_loss = checkpoint['best_val_loss']
+        elif self.args.init_from.startswith('gpt2'):
+            override_args = dict(dropout=self.args.dropout)
+            self.model = GPT.from_pretrained(self.args.init_from, override_args)
+            for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
+                self.model_args[k] = getattr(self.model.config, k)
+
+        if self.args.block_size < self.model.config.block_size:
+            self.model.crop_block_size(self.args.block_size)
+            self.model_args['block_size'] = self.args.block_size
+
+        self.model.to(self.device)
+
+        # Optimizer
+        self.scaler = torch.cuda.amp.GradScaler(enabled=(self.args.dtype == 'float16'))
+        self.optimizer = self.model.configure_optimizers(self.args.weight_decay, self.args.learning_rate,
+                                                         (self.args.beta1, self.args.beta2), self.device_type)
+
+        if self.args.compile:
+            print("compiling the model... (takes a ~minute)")
+            self.unoptimized_model = self.model
+            self.model = torch.compile(self.model)
+
+        if self.ddp:
+            self.model = DDP(self.model, device_ids=[self.ddp_local_rank])
+
+        self.raw_model = self.model.module if self.ddp else self.model
+
+        # Tensorboard
+        if self.args.tensorboard_log:
+            timestamp = time.strftime("%Y%m%d-%H%M%S")
+            log_subpath = os.path.join(self.args.tensorboard_log_dir, timestamp)
+            self.writer = SummaryWriter(log_subpath)
+
+        # Wandb
+        if self.args.wandb_log and self.master_process:
+            import wandb
+            wandb.init(project=self.args.wandb_project, name=self.args.wandb_run_name, config=self.args)
+
+    def get_batch(self, split):
+        data = self.train_data if split == 'train' else self.val_data
+        ix = torch.randint(len(data) - self.args.block_size, (self.args.batch_size,))
+        x = torch.stack([torch.from_numpy((data[i:i+self.args.block_size]).astype(np.int64)) for i in ix])
+        y = torch.stack([torch.from_numpy((data[i+1:i+1+self.args.block_size]).astype(np.int64)) for i in ix])
+        if self.device_type == 'cuda':
+            x, y = x.pin_memory().to(self.device, non_blocking=True), y.pin_memory().to(self.device, non_blocking=True)
+        else:
+            x, y = x.to(self.device), y.to(self.device)
+        return x, y
+
+    @torch.no_grad()
+    def estimate_loss(self):
+        out = {}
+        self.model.eval()
+        for split in ['train', 'val']:
+            losses = torch.zeros(self.args.eval_iters)
+            for k in range(self.args.eval_iters):
+                X, Y = self.get_batch(split)
+                with self.ctx:
+                    logits, loss = self.model(X, Y)
+                losses[k] = loss.item()
+            out[split] = losses.mean()
+        self.model.train()
+        return out
+
+    def get_lr(self, it):
+        if it < self.args.warmup_iters:
+            return self.args.learning_rate * it / self.args.warmup_iters
+        if it > self.args.lr_decay_iters:
+            return self.args.min_lr
+        decay_ratio = (it - self.args.warmup_iters) / (self.args.lr_decay_iters - self.args.warmup_iters)
+        assert 0 <= decay_ratio <= 1
+        coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
+        return self.args.min_lr + coeff * (self.args.learning_rate - self.args.min_lr)
+
+    def log_metrics(self, losses, lr, running_mfu, iter_num):
+        if self.args.tensorboard_log:
+            self.writer.add_scalars(
+                "loss", { "train": losses['train'], "val": losses['val'] }, iter_num
+            )
+            self.writer.add_scalar("mfu_pct", running_mfu * 100, iter_num)
+            self.writer.add_scalar("lr", lr, iter_num)
+
+        if self.args.wandb_log and self.master_process:
+            import wandb
             wandb.log({
                 "iter": iter_num,
                 "train/loss": losses['train'],
                 "val/loss": losses['val'],
                 "lr": lr,
-                "mfu": running_mfu*100, # convert to percentage
+                "mfu": running_mfu*100,
             })
-        if losses['val'] < best_val_loss or always_save_checkpoint:
-            best_val_loss = losses['val']
-            if iter_num > 0:
-                checkpoint = {
-                    'model': raw_model.state_dict(),
-                    'optimizer': optimizer.state_dict(),
-                    'model_args': model_args,
-                    'iter_num': iter_num,
-                    'best_val_loss': best_val_loss,
-                    'config': config,
-                }
-                if only_save_checkpoint_at_end == False:
-                  print(f"saving checkpoint to {out_dir}")
-                  torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
-    if iter_num == 0 and eval_only:
-        break
 
-    # forward backward update, with optional gradient accumulation to simulate larger batch size
-    # and using the GradScaler if data type is float16
-    for micro_step in range(gradient_accumulation_steps):
-        if ddp:
-            # in DDP training we only need to sync gradients at the last micro step.
-            # the official way to do this is with model.no_sync() context manager, but
-            # I really dislike that this bloats the code and forces us to repeat code
-            # looking at the source of that context manager, it just toggles this variable
-            model.require_backward_grad_sync = (micro_step == gradient_accumulation_steps - 1)
-        with ctx:
-            logits, loss = model(X, Y)
-            loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation
-        # immediately async prefetch next batch while model is doing the forward pass on the GPU
-        X, Y = get_batch('train')
-        # backward pass, with gradient scaling if training in fp16
-        scaler.scale(loss).backward()
-    # clip the gradient
-    if grad_clip != 0.0:
-        scaler.unscale_(optimizer)
-        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
-    # step the optimizer and scaler if training in fp16
-    scaler.step(optimizer)
-    scaler.update()
-    # flush the gradients as soon as we can, no need for this memory anymore
-    optimizer.zero_grad(set_to_none=True)
+    def train(self):
+        self.X, self.Y = self.get_batch('train')
+        t0 = time.time()
+        local_iter_num = 0
+        running_mfu = -1.0
 
-    # timing and logging
-    t1 = time.time()
-    dt = t1 - t0
-    t0 = t1
-    if iter_num % log_interval == 0 and master_process:
-        # get loss as float. note: this is a CPU-GPU sync point
-        # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
-        lossf = loss.item() * gradient_accumulation_steps
-        if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
-            running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
-        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
-    iter_num += 1
-    local_iter_num += 1
+        while True:
+            lr = self.get_lr(self.iter_num) if self.args.decay_lr else self.args.learning_rate
+            for param_group in self.optimizer.param_groups:
+                param_group['lr'] = lr
 
-    # termination conditions
-    if iter_num > max_iters:
-        if only_save_checkpoint_at_end:
-          print(f"saving checkpoint to {out_dir}")
-          torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
-        break
+            if self.iter_num % self.args.eval_interval == 0 and self.master_process:
+                losses = self.estimate_loss()
+                print(f"step {self.iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+                self.log_metrics(losses, lr, running_mfu, self.iter_num)
 
-writer.flush()
-writer.close()
+                if losses['val'] < self.best_val_loss or self.args.always_save_checkpoint:
+                    self.best_val_loss = losses['val']
+                    if self.iter_num > 0:
+                        checkpoint = {
+                            'model': self.raw_model.state_dict(),
+                            'optimizer': self.optimizer.state_dict(),
+                            'model_args': self.model_args,
+                            'iter_num': self.iter_num,
+                            'best_val_loss': self.best_val_loss,
+                            'config': vars(self.args),
+                        }
+                        print(f"saving checkpoint to {self.args.out_dir}")
+                        torch.save(checkpoint, os.path.join(self.args.out_dir, 'ckpt.pt'))
 
-if ddp:
-    destroy_process_group()
+            if self.iter_num == 0 and self.args.eval_only:
+                break
+
+            for micro_step in range(self.args.gradient_accumulation_steps):
+                if self.ddp:
+                    self.model.require_backward_grad_sync = (micro_step == self.args.gradient_accumulation_steps - 1)
+
+                with self.ctx:
+                    logits, loss = self.model(self.X, self.Y)
+                    loss = loss / self.args.gradient_accumulation_steps
+
+                self.X, self.Y = self.get_batch('train')
+
+                self.scaler.scale(loss).backward()
+
+            if self.args.grad_clip != 0.0:
+                self.scaler.unscale_(self.optimizer)
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.args.grad_clip)
+
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+
+            self.optimizer.zero_grad(set_to_none=True)
+
+            t1 = time.time()
+            dt = t1 - t0
+            t0 = t1
+            if self.iter_num % self.args.log_interval == 0 and self.master_process:
+                lossf = loss.item() * self.args.gradient_accumulation_steps
+                if local_iter_num >= 5:
+                    mfu = self.raw_model.estimate_mfu(self.args.batch_size * self.args.gradient_accumulation_steps, dt)
+                    running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
+                print(f"iter {self.iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
+
+            self.iter_num += 1
+            local_iter_num += 1
+
+            if self.iter_num > self.args.max_iters:
+                if self.args.only_save_checkpoint_at_end:
+                    checkpoint = {
+                        'model': self.raw_model.state_dict(),
+                        'optimizer': self.optimizer.state_dict(),
+                        'model_args': self.model_args,
+                        'iter_num': self.iter_num,
+                        'best_val_loss': self.best_val_loss,
+                        'config': self.args,
+                    }
+                    print(f"saving checkpoint to {self.args.out_dir}")
+                    torch.save(checkpoint, os.path.join(self.args.out_dir, 'ckpt.pt'))
+                break
+
+        if self.args.tensorboard_log:
+            self.writer.flush()
+            self.writer.close()
+
+        if self.args.wandb_log and self.master_process:
+            import wandb
+            wandb.log({"finished": True})
+            wandb.finish()
+
+def main():
+    args = parse_args()
+    print(args.device)
+    trainer = Trainer(args)
+    trainer.train()
+
+    if trainer.ddp:
+        destroy_process_group()
+
+    if args.tensorboard_log:
+        trainer.writer.flush()
+        trainer.writer.close()
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This addition of parameterization (argparse) **unblocks** the ability to schedule queues of large experiments.
 
Note: All of the capabilities and performance of the original are maintained, and with the defaults runs just as fast as the original (in milliseconds per iteration).

One can now create bash scripts (or add declarative files), to determine search spaces, and even hook in RL loops via open gym to the train.py script (using the params as handles).

Note: Since the configuration is completely handled within `train.py`, we no longer need the `configurator.py` file.

2nd Note: Next steps in this direction:
- Create more dynamic configuration files (e.g. ranges of train.py parameters) instead of the static parameter files in the config folder.
- Another PR for adding configuration details to each of the tensorboard logs
- Add RL Loop and argparse flags to reuse prior and trained RL loop agents