### PR TITLE
Add top level gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# folders
+__pycache__/
+logs/
+
+# file extensions
+*.pkl
+*.bin
+*.txt
+
+# checkpoint directories
+out*/


### PR DESCRIPTION
This will prevent logs, pycache, checkpoints, and intermediate files from being accidentally checked in.